### PR TITLE
fix: use version 2 of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-version: 1
+version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests


### PR DESCRIPTION
I misread the docs and you must use version 2 of dependabot