### PR TITLE
chore: fix git user permissions error with release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,15 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
+      # Image uses a custom user and it needs to own the workspace directory
+      # Note use of sudo to allow ownership change.
+      - name: Chown workspace to user
+        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: |
+          git config user.email "github@3box.io"
+          git config user.name "Github Automation"
       - name: Perform release
         run: make release


### PR DESCRIPTION
Previously the release action failed as permissions on the directories did not match the current user. Now the ownership is explicitly changed to be the builder user.