### PR TITLE
fix: use base64-url 2.0.2 with std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,7 @@ dag-json = ["dep:libipld-json"]
 
 [dependencies]
 anyhow = "1.0.69"
-base64-url = { version = "2.0.1", default-features = false }
-# base64-url no longer honors the std feature, we need to explicitly enable it on base64.
-base64 = { version = "0.21", default-features = false, features = [
-    "alloc",
-    "std",
-] }
+base64-url = { version = "2.0.2", feautres = ["std"] }
 libipld = { version = "0.16.0", default-features = false, features = [
     "serde-codec",
 ] }


### PR DESCRIPTION
The std feature was readded to the base64-url crate. We can now explicitly enable it. https://github.com/magiclen/base64-url/issues/6 