### PR TITLE
feat: update to use ipld-core crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,21 @@ repository = "https://github.com/ceramicnetwork/rust-dag-jose"
 resolver = "2"
 
 [features]
-dag-json = ["dep:libipld-json"]
+dag-json = ["dep:serde_ipld_dagjson"]
 
 [dependencies]
-anyhow = "1.0.69"
-base64-url = { version = "2.0.2", feautres = ["std"] }
-libipld = { version = "0.16.0", default-features = false, features = [
-    "serde-codec",
-] }
-libipld-json = { version = "0.16.0", default-features = false, optional = true }
-serde = "1.0.152"
-serde_derive = "1.0.152"
-serde_ipld_dagcbor = "0.3.0"
-thiserror = "1.0.38"
+anyhow = "1"
+base64-url = { version = "2.0.2" }
+ipld-core = { version = "0.4" }
+serde_ipld_dagjson = { version = "0.2", default-features = false, optional = true }
+serde_ipld_dagcbor = "0.6"
+serde = "1"
+serde_derive = "1"
+thiserror = "1"
 
 [dev-dependencies]
-assert-json-diff = "2.0.2"
-hex = "0.4.3"
-once_cell = "1.17.0"
-serde_json = "1.0.92"
+assert-json-diff = "2"
+hex = "0.4"
+once_cell = "1"
+serde_json = "1"
 testmark = { git = "https://github.com/bsundsrud/rust-testmark" }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2,7 +2,8 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-use libipld::{Cid, Ipld};
+use ipld_core::cid::Cid;
+use ipld_core::ipld::Ipld;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -25,6 +26,21 @@ pub struct Encoded {
     //
     // Within each grouping the fields are defined in their correct
     // sort order.
+    //
+    // Additionally according to the spec:
+    //
+    //  > Any field which is represented as base64url(<data>) we map directly to Bytes.
+    //
+    //  https://ipld.io/specs/codecs/dag-jose/spec/#mapping-from-the-jose-general-json-serialization-to-dag-jose-serialization
+    //
+    // This means that these fields are represented as a Bytes type of the raw bytes of the field
+    // so they can be DAB-CBOR encoded/decoded as raw bytes not a base64url encoded string..
+    //
+    // When we convert the data to a Jose object we construct the base64url encoded string from the
+    // raw bytes.
+    //
+    // The dag-json feature takes advantage of this to encode the Jose structs directly preserving
+    // the base64url encoded string.
 
     // JWS fields
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 //! JOSE error types.
-use base64_url::base64::DecodeError;
-use libipld::cid;
+use ipld_core::cid;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -12,5 +11,17 @@ pub enum Error {
     #[error("invalid CID data in payload")]
     InvalidCid(#[from] cid::Error),
     #[error("invalid base64 url data")]
-    InvalidBase64Url(#[from] DecodeError),
+    InvalidBase64Url(#[from] base64_url::base64::DecodeError),
+    #[error("invalid cbor encoding")]
+    Codec(#[from] serde_ipld_dagcbor::error::CodecError),
+    #[error("failed encoding")]
+    CborEncode(#[from] serde_ipld_dagcbor::EncodeError<std::io::Error>),
+    #[error("failed decoding")]
+    CborDecode(#[from] serde_ipld_dagcbor::DecodeError<std::io::Error>),
+    #[cfg(feature = "dag-json")]
+    #[error("failed encoding")]
+    JsonEncode(#[from] serde_ipld_dagjson::EncodeError),
+    #[cfg(feature = "dag-json")]
+    #[error("failed decoding")]
+    JsonDecode(#[from] serde_ipld_dagjson::DecodeError),
 }


### PR DESCRIPTION
The Rust crate libipld is no longer the _blessed_ implementation of IPLD in Rust. This change updates to use the ipld-core implementation so this crate can interoperate well with the ecosystem.