### PR TITLE
chore: fix permissions on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,16 @@ jobs:
     container:
       # See https://github.com/3box/rust-builder
       image: public.ecr.aws/r5b3e0r5/3box/rust-builder:latest
+      options: --user root
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: |
+          chown root:root -R .
           git config user.email "github@3box.io"
           git config user.name "Github Automation"
       - name: Perform release


### PR DESCRIPTION
Same fix as #36 for the release workflow